### PR TITLE
Fix tests for new handling of module stability feature

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,3 +62,5 @@ If you’re interested in contributing code, please have a look at our [style gu
 If you have a case that is not covered in the style guide, simply do your best to match the style of the surrounding code.
 
 **Thanks for contributing! :boom::camel:**
+
+By submitting a pull request, you represent that you have the right to license your contribution to Carthage and the community, and agree by submitting the patch that your contributions are licensed under the MIT License.

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -140,20 +140,28 @@ internal func checkSwiftFrameworkCompatibility(_ frameworkURL: URL, usingToolcha
 		}
 }
 
-private func isModuleStableAPI(_ localSwiftVersion: String,
-							   _ frameworkSwiftVersion: String,
-							   _ frameworkURL: URL) -> Bool {
-	guard let localSwiftVersionNumber = Double(localSwiftVersion.prefix(3)),
-		let frameworkSwiftVersionNumber = Double(frameworkSwiftVersion.prefix(3)) else { return false }
-	guard let swiftModuleURL = frameworkURL.swiftmoduleURL() else { return false }
+/// Determines whether a local swift version and a framework combination are considered module stable
+internal func isModuleStableAPI(_ localSwiftVersion: String,
+                                _ frameworkSwiftVersion: String,
+                                _ frameworkURL: URL) -> Bool {
+    guard let localSwiftVersionNumber = determineMajorMinorVersion(localSwiftVersion),
+        let frameworkSwiftVersionNumber = determineMajorMinorVersion(frameworkSwiftVersion),
+        let swiftModuleURL = frameworkURL.swiftmoduleURL() else { return false }
 
-	let hasSwiftInterfaceFile = try? FileManager.default.contentsOfDirectory(at: swiftModuleURL,
-																			 includingPropertiesForKeys: nil,
-																			 options: []).first { (url) -> Bool in
-			return url.lastPathComponent.contains("swiftinterface")
-		} != nil
+    let hasSwiftInterfaceFile = try? FileManager.default.contentsOfDirectory(at: swiftModuleURL,
+                                                                             includingPropertiesForKeys: nil,
+                                                                             options: []).first { (url) -> Bool in
+            return url.lastPathComponent.contains("swiftinterface")
+        } != nil
 
-	return localSwiftVersionNumber >= 5.1 && frameworkSwiftVersionNumber >= 5.1 && hasSwiftInterfaceFile == true
+    return localSwiftVersionNumber >= 5.1 && frameworkSwiftVersionNumber >= 5.1 && hasSwiftInterfaceFile == true
+}
+
+/// Attempts to return a `Double` representing the major/minor version components parsed from a given swift version, otherwise returns `nil`.
+private func determineMajorMinorVersion(_ swiftVersion: String) -> Double? {
+    guard let range = swiftVersion.range(of: "^(\\d+)\\.(\\d+)", options: .regularExpression) else { return nil }
+
+    return Double(swiftVersion[range])
 }
 
 /// Emits the framework URL if it is compatible with the build environment and errors if not.

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -142,26 +142,26 @@ internal func checkSwiftFrameworkCompatibility(_ frameworkURL: URL, usingToolcha
 
 /// Determines whether a local swift version and a framework combination are considered module stable
 internal func isModuleStableAPI(_ localSwiftVersion: String,
-                                _ frameworkSwiftVersion: String,
-                                _ frameworkURL: URL) -> Bool {
-    guard let localSwiftVersionNumber = determineMajorMinorVersion(localSwiftVersion),
-        let frameworkSwiftVersionNumber = determineMajorMinorVersion(frameworkSwiftVersion),
-        let swiftModuleURL = frameworkURL.swiftmoduleURL() else { return false }
+								_ frameworkSwiftVersion: String,
+								_ frameworkURL: URL) -> Bool {
+	guard let localSwiftVersionNumber = determineMajorMinorVersion(localSwiftVersion),
+		let frameworkSwiftVersionNumber = determineMajorMinorVersion(frameworkSwiftVersion),
+		let swiftModuleURL = frameworkURL.swiftmoduleURL() else { return false }
 
-    let hasSwiftInterfaceFile = try? FileManager.default.contentsOfDirectory(at: swiftModuleURL,
-                                                                             includingPropertiesForKeys: nil,
-                                                                             options: []).first { (url) -> Bool in
-            return url.lastPathComponent.contains("swiftinterface")
-        } != nil
+	let hasSwiftInterfaceFile = try? FileManager.default.contentsOfDirectory(at: swiftModuleURL,
+																			 includingPropertiesForKeys: nil,
+																			 options: []).first { (url) -> Bool in
+																				return url.lastPathComponent.contains("swiftinterface")
+		} != nil
 
-    return localSwiftVersionNumber >= 5.1 && frameworkSwiftVersionNumber >= 5.1 && hasSwiftInterfaceFile == true
+	return localSwiftVersionNumber >= 5.1 && frameworkSwiftVersionNumber >= 5.1 && hasSwiftInterfaceFile == true
 }
 
 /// Attempts to return a `Double` representing the major/minor version components parsed from a given swift version, otherwise returns `nil`.
 private func determineMajorMinorVersion(_ swiftVersion: String) -> Double? {
-    guard let range = swiftVersion.range(of: "^(\\d+)\\.(\\d+)", options: .regularExpression) else { return nil }
+	guard let range = swiftVersion.range(of: "^(\\d+)\\.(\\d+)", options: .regularExpression) else { return nil }
 
-    return Double(swiftVersion[range])
+	return Double(swiftVersion[range])
 }
 
 /// Emits the framework URL if it is compatible with the build environment and errors if not.

--- a/Source/CarthageKit/Xcode.swift
+++ b/Source/CarthageKit/Xcode.swift
@@ -151,7 +151,7 @@ internal func isModuleStableAPI(_ localSwiftVersion: String,
 	let hasSwiftInterfaceFile = try? FileManager.default.contentsOfDirectory(at: swiftModuleURL,
 																			 includingPropertiesForKeys: nil,
 																			 options: []).first { (url) -> Bool in
-																				return url.lastPathComponent.contains("swiftinterface")
+			return url.lastPathComponent.contains("swiftinterface")
 		} != nil
 
 	return localSwiftVersionNumber >= 5.1 && frameworkSwiftVersionNumber >= 5.1 && hasSwiftInterfaceFile == true

--- a/Tests/CarthageKitTests/XcodeSpec.swift
+++ b/Tests/CarthageKitTests/XcodeSpec.swift
@@ -375,7 +375,7 @@ class XcodeSpec: QuickSpec {
 			let versionFileURL = URL(fileURLWithPath: buildFolderURL.appendingPathComponent(".Archimedes.version").path)
 			let versionFile = VersionFile(url: versionFileURL)
 			expect(versionFile).notTo(beNil())
-
+			
 			// Verify that the other platform wasn't built.
 			let incorrectPath = buildFolderURL.appendingPathComponent("iOS/\(dependency.name).framework").path
 			expect(FileManager.default.fileExists(atPath: incorrectPath, isDirectory: nil)) == false

--- a/Tests/CarthageKitTests/XcodeSpec.swift
+++ b/Tests/CarthageKitTests/XcodeSpec.swift
@@ -100,31 +100,31 @@ class XcodeSpec: QuickSpec {
 			}
 
 			it("should determine when a module-stable Swift framework is incompatible") {
-                let localSwiftVersion = "5.0 (swiftlang-1001.0.69.5 clang-1001.0.46.3)"
-                let frameworkVersion = "5.1.2 (swiftlang-1100.0.278 clang-1100.0.33.9)"
-                let frameworkURL = Bundle(for: type(of: self)).url(forResource: "ModuleStableBuiltWithSwift5.1.2.framework", withExtension: nil)!
-                let result = isModuleStableAPI(localSwiftVersion, frameworkVersion, frameworkURL)
+				let localSwiftVersion = "5.0 (swiftlang-1001.0.69.5 clang-1001.0.46.3)"
+				let frameworkVersion = "5.1.2 (swiftlang-1100.0.278 clang-1100.0.33.9)"
+				let frameworkURL = Bundle(for: type(of: self)).url(forResource: "ModuleStableBuiltWithSwift5.1.2.framework", withExtension: nil)!
+				let result = isModuleStableAPI(localSwiftVersion, frameworkVersion, frameworkURL)
 
-                expect(result).to(beFalse())
-            }
+				expect(result).to(beFalse())
+			}
 
-            it("should determine when a non-module-stable Swift framework is incompatible") {
-                let localSwiftVersion = "5.1 (swiftlang-1100.0.270.13 clang-1100.0.33.7)"
-                let frameworkVersion = "5.1.2 (swiftlang-1100.0.278 clang-1100.0.33.9)"
-                let frameworkURL = Bundle(for: type(of: self)).url(forResource: "NonModuleStableBuiltWithSwift5.1.2.framework", withExtension: nil)!
-                let result = isModuleStableAPI(localSwiftVersion, frameworkVersion, frameworkURL)
+			it("should determine when a non-module-stable Swift framework is incompatible") {
+				let localSwiftVersion = "5.1 (swiftlang-1100.0.270.13 clang-1100.0.33.7)"
+				let frameworkVersion = "5.1.2 (swiftlang-1100.0.278 clang-1100.0.33.9)"
+				let frameworkURL = Bundle(for: type(of: self)).url(forResource: "NonModuleStableBuiltWithSwift5.1.2.framework", withExtension: nil)!
+				let result = isModuleStableAPI(localSwiftVersion, frameworkVersion, frameworkURL)
 
-                expect(result).to(beFalse())
-            }
+				expect(result).to(beFalse())
+			}
 
-            it("should determine when a module-stable Swift framework is compatible") {
-                let localSwiftVersion = "5.1 (swiftlang-1100.0.270.13 clang-1100.0.33.7)"
-                let frameworkVersion = "5.1.2 (swiftlang-1100.0.278 clang-1100.0.33.9)"
-                let frameworkURL = Bundle(for: type(of: self)).url(forResource: "ModuleStableBuiltWithSwift5.1.2.framework", withExtension: nil)!
-                let result = isModuleStableAPI(localSwiftVersion, frameworkVersion, frameworkURL)
+			it("should determine when a module-stable Swift framework is compatible") {
+				let localSwiftVersion = "5.1 (swiftlang-1100.0.270.13 clang-1100.0.33.7)"
+				let frameworkVersion = "5.1.2 (swiftlang-1100.0.278 clang-1100.0.33.9)"
+				let frameworkURL = Bundle(for: type(of: self)).url(forResource: "ModuleStableBuiltWithSwift5.1.2.framework", withExtension: nil)!
+				let result = isModuleStableAPI(localSwiftVersion, frameworkVersion, frameworkURL)
 
-                expect(result).to(beTrue())
-            }
+				expect(result).to(beTrue())
+			}
 		}
 
 		describe("locateProjectsInDirectory:") {

--- a/Tests/CarthageKitTests/XcodeSpec.swift
+++ b/Tests/CarthageKitTests/XcodeSpec.swift
@@ -100,31 +100,31 @@ class XcodeSpec: QuickSpec {
 			}
 
 			it("should determine when a module-stable Swift framework is incompatible") {
-				let frameworkURL = Bundle(for: type(of: self)).url(forResource: "ModuleStableBuiltWithSwift5.1.2.framework", withExtension: nil)!
-				let swift5Dot0Toolchain = "Apple Swift version 5.0 (swiftlang-1001.0.69.5 clang-1001.0.46.3)"
-				let result = checkSwiftFrameworkCompatibility(frameworkURL, usingToolchain: swift5Dot0Toolchain).single()
+                let localSwiftVersion = "5.0 (swiftlang-1001.0.69.5 clang-1001.0.46.3)"
+                let frameworkVersion = "5.1.2 (swiftlang-1100.0.278 clang-1100.0.33.9)"
+                let frameworkURL = Bundle(for: type(of: self)).url(forResource: "ModuleStableBuiltWithSwift5.1.2.framework", withExtension: nil)!
+                let result = isModuleStableAPI(localSwiftVersion, frameworkVersion, frameworkURL)
 
-				expect(result?.value).to(beNil())
-				expect(result?.error) == .incompatibleFrameworkSwiftVersions(local: "5.0 (swiftlang-1001.0.69.5 clang-1001.0.46.3)", framework: "5.1.2 (swiftlang-1100.0.278 clang-1100.0.33.9)")
-			}
+                expect(result).to(beFalse())
+            }
 
-			it("should determine when a non-module-stable Swift framework is incompatible") {
-				let frameworkURL = Bundle(for: type(of: self)).url(forResource: "NonModuleStableBuiltWithSwift5.1.2.framework", withExtension: nil)!
-				let swift5Dot1Toolchain = "5.1 (swiftlang-1100.0.270.13 clang-1100.0.33.7)"
-				let result = checkSwiftFrameworkCompatibility(frameworkURL, usingToolchain: swift5Dot1Toolchain).single()
+            it("should determine when a non-module-stable Swift framework is incompatible") {
+                let localSwiftVersion = "5.1 (swiftlang-1100.0.270.13 clang-1100.0.33.7)"
+                let frameworkVersion = "5.1.2 (swiftlang-1100.0.278 clang-1100.0.33.9)"
+                let frameworkURL = Bundle(for: type(of: self)).url(forResource: "NonModuleStableBuiltWithSwift5.1.2.framework", withExtension: nil)!
+                let result = isModuleStableAPI(localSwiftVersion, frameworkVersion, frameworkURL)
 
-				expect(result?.value).to(beNil())
-				expect(result?.error) == .incompatibleFrameworkSwiftVersions(local: swift5Dot1Toolchain, framework: "5.1.2 (swiftlang-1100.0.278 clang-1100.0.33.9)")
-			}
+                expect(result).to(beFalse())
+            }
 
-			it("should determine when a module-stable Swift framework is compatible") {
-				let frameworkURL = Bundle(for: type(of: self)).url(forResource: "ModuleStableBuiltWithSwift5.1.2.framework", withExtension: nil)!
-				let swift5Dot1Toolchain = "5.1 (swiftlang-1100.0.270.13 clang-1100.0.33.7)"
-				let result = checkSwiftFrameworkCompatibility(frameworkURL, usingToolchain: swift5Dot1Toolchain).single()
+            it("should determine when a module-stable Swift framework is compatible") {
+                let localSwiftVersion = "5.1 (swiftlang-1100.0.270.13 clang-1100.0.33.7)"
+                let frameworkVersion = "5.1.2 (swiftlang-1100.0.278 clang-1100.0.33.9)"
+                let frameworkURL = Bundle(for: type(of: self)).url(forResource: "ModuleStableBuiltWithSwift5.1.2.framework", withExtension: nil)!
+                let result = isModuleStableAPI(localSwiftVersion, frameworkVersion, frameworkURL)
 
-				expect(result?.value) == frameworkURL
-				expect(result?.error).to(beNil())
-			}
+                expect(result).to(beTrue())
+            }
 		}
 
 		describe("locateProjectsInDirectory:") {
@@ -375,7 +375,7 @@ class XcodeSpec: QuickSpec {
 			let versionFileURL = URL(fileURLWithPath: buildFolderURL.appendingPathComponent(".Archimedes.version").path)
 			let versionFile = VersionFile(url: versionFileURL)
 			expect(versionFile).notTo(beNil())
-			
+
 			// Verify that the other platform wasn't built.
 			let incorrectPath = buildFolderURL.appendingPathComponent("iOS/\(dependency.name).framework").path
 			expect(FileManager.default.fileExists(atPath: incorrectPath, isDirectory: nil)) == false


### PR DESCRIPTION
@DavidBrunow I've included my suggested changes in this PR.

1. I've marked the `isModuleStableAPI()` as `internal` so that it can be tested directly.
2. I've updated the tests you added accordingly.
3. I changed the parsing of the swift version inside of `isModuleStableAPI()` to use regex pattern matching rather than assuming it is represented in the first 3 characters. This was done to hopefully prevent the new logic from failing for newer versions of Swift in the future (e.g. 5.10, 10.0).

Thanks for implementing this feature and I hope this helps you to get it across the finish line.

/cheers 🍻 