### PR TITLE
Use swift toolchains in integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ DerivedData
 Carthage.pkg
 CarthageApp.pkg
 Carthage.xcodeproj/
+Toolchains/

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ test:
 	$(CP) -R Tests/CarthageKitTests/Resources ./.build/debug/CarthagePackageTests.xctest/Contents
 	$(CP) Tests/CarthageKitTests/fixtures/CartfilePrivateOnly.zip ./.build/debug/CarthagePackageTests.xctest/Contents/Resources
 	script/copy-fixtures ./.build/debug/CarthagePackageTests.xctest/Contents/Resources
+	$(SUDO) ./script/install-swift-toolchains.sh
 	swift test --skip-build
 
 installables:

--- a/script/install-swift-toolchains.sh
+++ b/script/install-swift-toolchains.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+declare -a toolchains=("swift-5.0-RELEASE" "swift-5.1-RELEASE")
+
+is_toolchain_installed() {
+
+  [[ $1 =~ [0-9\.]+ ]]
+  version="${BASH_REMATCH[0]}"
+
+  toolchain_id=$(plutil -extract CFBundleIdentifier xml1 -o - "/Library/Developer/Toolchains/${1}.xctoolchain/Info.plist" | sed -n "s/.*<string>\(.*\)<\/string>.*/\1/p")
+  reported_version=$(xcrun --toolchain "$toolchain_id" swift --version)
+  
+  regex="Apple Swift version $version \($1\)"
+  if [[ $reported_version =~ $regex ]]; then
+    true
+  else
+    false
+  fi  
+}
+
+for toolchain in "${toolchains[@]}"; do
+
+  echo ""
+
+  echo "Checking for toolchain ${toolchain}..."
+  if is_toolchain_installed $toolchain; then
+    echo "Already installed, skipping..."
+    continue
+  else
+    echo "Not found"
+  fi
+
+  mkdir -p "Toolchains"
+
+  echo "Downloading toolchain ${toolchain}..."
+  lower=$(echo "$toolchain" | awk '{print tolower($0)}')
+  (cd Toolchains && curl -O "https://swift.org/builds/${lower}/xcode/${toolchain}/${toolchain}-osx.pkg")
+
+  echo "Extracting package..."
+  (cd Toolchains && xar -xf "${toolchain}-osx.pkg")
+  
+  echo "Creating destination directory..."
+  sudo mkdir -p "/Library/Developer/Toolchains/${toolchain}.xctoolchain"
+  
+  echo "Installing toolchain..."
+  sudo tar -xzf "Toolchains/${toolchain}-osx-package.pkg/Payload" -C "/Library/Developer/Toolchains/${toolchain}.xctoolchain"
+
+  echo "Verifying installation..."
+  if is_toolchain_installed $toolchain; then
+    echo "Installed successfully"
+  else
+    echo "ERROR: Failed to install toolchain ${toolchain}"
+    exit 1
+  fi
+
+done
+
+echo ""


### PR DESCRIPTION
@DavidBrunow This branch demonstrates how we could do the full integration testing that you originally intended.

I added a script that checks for the presence of specific swift toolchains, and downloads them if necessary. This should run just fine on a CI machine as well as for a local user. I think the tests are fine as they are now, but thought this was a useful exercise.